### PR TITLE
add Kotlin based REST sample

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 
     <modules>
         <module>rest-trivial</module>
+        <module>rest-trivial-kotlin</module>
         <module>rest</module>
         <module>servlet-trivial</module>
         <module>mw_bundle_config</module>

--- a/rest-trivial-kotlin/README.adoc
+++ b/rest-trivial-kotlin/README.adoc
@@ -1,0 +1,11 @@
+= Apache Meecrowave
+
+== Trivial REST Example (rewritten in Kotlin)
+
+This example shows probably the smallest JavaEE REST Service.
+It is the REST version of the famous 'Hello World' program.
+It contains just a link:src/main/kotlin/com/superbiz/jaxrs/HelloEndpoint.kt[Hello Resource].
+The important part of this class are the `@Path("helloKotlin")` and the `@GET' annotated method.
+
+Note that the Resource is a CDI bean annotated with `@ApplicationScoped`.
+Thus only one instance exists.

--- a/rest-trivial-kotlin/pom.xml
+++ b/rest-trivial-kotlin/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.meecrowave</groupId>
+        <artifactId>meecrowave-examples</artifactId>
+        <version>1.2.5-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>samples-rest-trivial-kotlin</artifactId>
+    <name>REST (trivial) - Kotlin</name>
+
+    <properties>
+        <kotlin.version>1.2.71</kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+
+        <!-- this package contains the javax APIs for CDI, JAX-RS, JSONP, JSONB and Servlet4 -->
+        <dependency>
+            <groupId>org.apache.meecrowave</groupId>
+            <artifactId>meecrowave-specs-api</artifactId>
+            <version>${meecrowave.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.meecrowave</groupId>
+            <artifactId>meecrowave-core</artifactId>
+            <version>${meecrowave.version}</version>
+        </dependency>
+
+        <!-- our test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.meecrowave</groupId>
+            <artifactId>meecrowave-junit</artifactId>
+            <version>${meecrowave.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!--
+                    For starting meecrowave via Maven. Just run
+                    $> mvn clean install meecrowave:run
+                -->
+                <groupId>org.apache.meecrowave</groupId>
+                <artifactId>meecrowave-maven-plugin</artifactId>
+                <version>${meecrowave.version}</version>
+            </plugin>
+
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <configuration>
+                    <compilerPlugins>
+                        <plugin>all-open</plugin>
+                    </compilerPlugins>
+                    <pluginOptions>
+                        <option>all-open:annotation=javax.enterprise.context.ApplicationScoped</option>
+                    </pluginOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/rest-trivial-kotlin/src/main/kotlin/com/superbiz/jaxrs/HelloFromKotlinEndpoint.kt
+++ b/rest-trivial-kotlin/src/main/kotlin/com/superbiz/jaxrs/HelloFromKotlinEndpoint.kt
@@ -1,0 +1,18 @@
+package com.superbiz.jaxrs
+
+import javax.enterprise.context.ApplicationScoped
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+@Path("helloKotlin")
+@ApplicationScoped
+class HelloFromKotlinEndpoint {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    fun sayHi(): String {
+        return "Hello World from Kotlin"
+    }
+}

--- a/rest-trivial-kotlin/src/test/kotlin/com/superbiz/jaxrs/HelloFromKotlinEndpointTest.kt
+++ b/rest-trivial-kotlin/src/test/kotlin/com/superbiz/jaxrs/HelloFromKotlinEndpointTest.kt
@@ -1,0 +1,30 @@
+package com.superbiz.jaxrs
+
+import org.apache.meecrowave.Meecrowave
+import org.apache.meecrowave.junit.MonoMeecrowave
+import org.apache.meecrowave.testing.ConfigurationInject
+import org.junit.runner.RunWith
+import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(MonoMeecrowave.Runner::class)
+class HelloFromKotlinEndpointTest {
+
+    @ConfigurationInject
+    private lateinit var configuration: Meecrowave.Builder
+
+    @Test
+    fun `client answeres on path "hello"`() {
+        val client = ClientBuilder.newClient()
+        try {
+            assertEquals("Hello World from Kotlin", client.target("http://localhost:" + configuration.httpPort)
+                    .path("/helloKotlin")
+                    .request(APPLICATION_JSON_TYPE)
+                    .get(String::class.java))
+        } finally {
+            client.close()
+        }
+    }
+}


### PR DESCRIPTION
Adds a minimal Kotlin based REST endpoint sample.
https://issues.apache.org/jira/projects/MEECROWAVE/issues/MEECROWAVE-155